### PR TITLE
Adds an `activeSection` prop to the Accordion

### DIFF
--- a/Accordion.js
+++ b/Accordion.js
@@ -25,11 +25,13 @@ var Accordion = React.createClass({
     align:          React.PropTypes.oneOf(['top', 'center', 'bottom']),
     duration:       React.PropTypes.number,
     easing:         React.PropTypes.string,
+    activeSection:  React.PropTypes.number,
   },
 
   getInitialState: function() : Object {
+    var activeSection = this.props.activeSection;
     return {
-      activeSection: false
+      activeSection: activeSection === null || activeSection === undefined ? false : activeSection
     };
   },
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ var Accordion = require('react-native-collapsible/Accordion');
 |**`renderHeader(content, index, isActive)`**|A function that should return a renderable representing the header|
 |**`renderContent(content, index, isActive)`**|A function that should return a renderable representing the content|
 |**`onChange(index)`**|An optional function that is called when currently active section is changed, `index === false` when collapsed|
+|**`activeSection`**|An optional index of the section to be initially active.|
 |**`align`**|See `Collapsible`|
 |**`duration`**|See `Collapsible`|
 |**`easing`**|See `Collapsible`|


### PR DESCRIPTION
The `activeSection` prop is an optional index that allows for a section to be initially active. I thought this might be handy to have if one wanted one of the section to be displayed by default. Also, I am not tied to the property name or anything. I am open to alternative names if you have a preference.