### PR TITLE
Animating state now changes back to false after animation

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -82,7 +82,7 @@ var Collapsible = React.createClass({
       toValue: height,
       duration,
       easing,
-    }).start(event => this.setState({ animating: true }));
+    }).start(event => this.setState({ animating: false }));
   },
 
   _handleLayoutChange(event : Object) : void {


### PR DESCRIPTION
In master animated state is set to true after animation is done. This prevents on layout to be triggered after first collapse/show. This fix returns the animation state to false after animation so that the collapsible view will adapt to size changes of the content after animation.