### PR TITLE
Adding prop to force activeSection

### DIFF
--- a/Accordion.js
+++ b/Accordion.js
@@ -23,6 +23,10 @@ class Accordion extends Component {
     duration: PropTypes.number,
     easing: PropTypes.string,
     initiallyActiveSection: PropTypes.number,
+    activeSection: PropTypes.oneOfType([
+      PropTypes.bool, // if false, closes all sections
+      PropTypes.number, // sets index of section to open
+    ]),
     underlayColor: PropTypes.string,
   };
 
@@ -33,16 +37,28 @@ class Accordion extends Component {
   constructor(props) {
     super(props);
 
+    // if activeSection not specified, default to initiallyActiveSection
     this.state = {
-      activeSection: props.initiallyActiveSection,
+      activeSection: props.activeSection !== undefined ? props.activeSection : props.initiallyActiveSection,
     };
   }
 
   _toggleSection(section) {
     const activeSection = this.state.activeSection === section ? false : section;
-    this.setState({ activeSection });
+
+    if (this.props.activeSection === undefined) {
+      this.setState({ activeSection });
+    }
     if (this.props.onChange) {
       this.props.onChange(activeSection);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.activeSection !== undefined) {
+      this.setState({
+        activeSection: nextProps.activeSection,
+      });
     }
   }
 

--- a/Example/app.js
+++ b/Example/app.js
@@ -67,6 +67,12 @@ const styles = StyleSheet.create({
   inactive: {
     backgroundColor: 'rgba(245,252,255,1)',
   },
+  buttons: {
+    marginTop: 10,
+  },
+  button: {
+    margin: 10,
+  },
 });
 
 export default class ExampleView extends Component {
@@ -110,12 +116,52 @@ export default class ExampleView extends Component {
             <Text>Bacon ipsum dolor amet chuck turducken landjaeger tongue spare ribs</Text>
           </View>
         </Collapsible>
-        <Accordion
+        <Accordion activeSection={this.state.activeSection}
           sections={CONTENT}
           renderHeader={this._renderHeader}
           renderContent={this._renderContent}
           duration={400}
+          onChange={(num) => {
+            this.setState({
+              activeSection: num,
+            });
+          }}
         />
+
+        <View style={styles.buttons}>
+          <TouchableHighlight
+            style={styles.button}
+            onPress={() => {
+              this.setState({
+                activeSection: 0,
+              });
+            }}
+          >
+            <Text>{'Select First'}</Text>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+            style={styles.button}
+            onPress={() => {
+              this.setState({
+                activeSection: 2,
+              });
+            }}
+          >
+            <Text>{'Select Third'}</Text>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+            style={styles.button}
+            onPress={() => {
+              this.setState({
+                activeSection: false,
+              });
+            }}
+          >
+            <Text>{'Reset'}</Text>
+          </TouchableHighlight>
+        </View>
       </View>
     );
   }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ import Accordion from 'react-native-collapsible/Accordion';
 |**`renderHeader(content, index, isActive)`**|A function that should return a renderable representing the header|
 |**`renderContent(content, index, isActive)`**|A function that should return a renderable representing the content|
 |**`onChange(index)`**|An optional function that is called when currently active section is changed, `index === false` when collapsed|
-|**`initiallyActiveSection`**|Which index in the `sections` array to be initially open. Defaults to none. |
+|**`initiallyActiveSection`**|Set which index in the `sections` array is initially open. Defaults to none. |
+|**`activeSection`**|Control which index in the `sections` array is currently open. Defaults to none. If false, closes all sections.|
 |**`underlayColor`**|The color of the underlay that will show through when tapping on headers. Defaults to black. |
 |**`align`**|See `Collapsible`|
 |**`duration`**|See `Collapsible`|


### PR DESCRIPTION
Adding prop to be able to specify the activeSection externally. This is useful when the item inside the Accordion (e.g. a "Next" button)can trigger the following item to auto-expand.