### PR TITLE
make content view to respond to dynamic height change during animation transition

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -86,7 +86,7 @@ class Collapsible extends Component {
     }).start(event => this.setState({ animating: false }));
   }
 
-  _handleLayoutChange(event) {
+  _handleLayoutChange = (event) => {
     const contentHeight = event.nativeEvent.layout.height;
     const height = this.props.collapsed ? this.props.collapsedHeight : contentHeight;
     this.setState({
@@ -119,7 +119,7 @@ class Collapsible extends Component {
     }
     return (
       <Animated.View style={style} pointerEvents={this.props.collapsed ? 'none' : 'auto'}>
-        <Animated.View style={[this.props.style, contentStyle]} onLayout={this.state.animating ? undefined : event => this._handleLayoutChange(event)}>
+        <Animated.View style={[this.props.style, contentStyle]} onLayout={this._handleLayoutChange}>
           {this.props.children}
         </Animated.View>
       </Animated.View>


### PR DESCRIPTION
Existing check does not work in some cases, 

In my case it start loading data on the expand and it can get data before animation ends, so should start new transition with up to date content height ...

Let me know if you need more details, I can provide an example