### PR TITLE
Replace React.PropTypes with prop-types package

### DIFF
--- a/Accordion.js
+++ b/Accordion.js
@@ -1,7 +1,7 @@
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   View,

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -1,7 +1,7 @@
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   Animated,

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "babel-eslint": "^4.1.6",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.14.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
PropTypes from the react package was deprecated and moved to `prop-types` in reactv15.5 so it shows errors in react native projects.

This PR makes the fix for PropTypes