### PR TITLE
Replace TouchableHighlight with TouchableOpacity

### DIFF
--- a/Accordion.js
+++ b/Accordion.js
@@ -5,7 +5,7 @@ import React, {
 
 import {
   View,
-  TouchableHighlight,
+  TouchableOpacity,
 } from 'react-native';
 
 import Collapsible from './Collapsible';
@@ -28,10 +28,12 @@ class Accordion extends Component {
       PropTypes.number, // sets index of section to open
     ]),
     underlayColor: PropTypes.string,
+    activeOpacity: PropTypes.Number
   };
 
   static defaultProps = {
     underlayColor: 'black',
+    activeOpacity: 0.2
   };
 
   constructor(props) {
@@ -77,9 +79,9 @@ class Accordion extends Component {
       <View {...viewProps}>
       {this.props.sections.map((section, key) => (
         <View key={key}>
-          <TouchableHighlight onPress={() => this._toggleSection(key)} underlayColor={this.props.underlayColor}>
+          <TouchableOpacity onPress={() => this._toggleSection(key)} underlayColor={this.props.underlayColor} activeOpacity={this.props.activeOpacity}>
             {this.props.renderHeader(section, key, this.state.activeSection === key)}
-          </TouchableHighlight>
+          </TouchableOpacity>
           <Collapsible collapsed={this.state.activeSection !== key} {...collapsibleProps}>
             {this.props.renderContent(section, key, this.state.activeSection === key)}
           </Collapsible>

--- a/Accordion.js
+++ b/Accordion.js
@@ -28,7 +28,7 @@ class Accordion extends Component {
       PropTypes.number, // sets index of section to open
     ]),
     underlayColor: PropTypes.string,
-    activeOpacity: PropTypes.Number
+    activeOpacity: PropTypes.number
   };
 
   static defaultProps = {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ import Accordion from 'react-native-collapsible/Accordion';
 |**`initiallyActiveSection`**|Set which index in the `sections` array is initially open. Defaults to none. |
 |**`activeSection`**|Control which index in the `sections` array is currently open. Defaults to none. If false, closes all sections.|
 |**`underlayColor`**|The color of the underlay that will show through when tapping on headers. Defaults to black. |
+|**`activeOpacity`**|Determines what the opacity of the header should be when touch is active. Defaults to 0.2. |
 |**`align`**|See `Collapsible`|
 |**`duration`**|See `Collapsible`|
 |**`easing`**|See `Collapsible`|


### PR DESCRIPTION
Replace `TouchableHighlight` with `TouchableOpacity`, add `activeOpacity` prop. It should prevent renderHeader method errors, when it returns not a native component. 
![iphone 6 ios 10 3 14e8301 2017-07-19 20-51-10](https://user-images.githubusercontent.com/2942880/28381655-5299f356-6cc4-11e7-9701-816cc1aa9435.png)
