### PR TITLE
Fixed broken relative import in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare module 'react-native-collapsible' {
 
 declare module 'react-native-collapsible/Accordion' {
   import * as React from 'react';
-  import { EasingMode } from './index';
+  import { EasingMode } from 'react-native-collapsible';
 
   export interface AccordionProps {
     /**


### PR DESCRIPTION
Fixed following build error:

```
node_modules/react-native-collapsible/index.d.ts(79,3): error TS2439: Import or export declaration in an ambient module declaration cannot reference module through relative module name.
node_modules/react-native-collapsible/index.d.ts(79,30): error TS2307: Cannot find module './index'.
```