### PR TITLE
Handle rapid changes to collapsed prop

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -95,6 +95,11 @@ export default class Collapsible extends Component {
     );
   }
 
+  _afterMeasure = () => {
+    this._toggleCollapsed(this.props.collapsed);
+  }
+
+
   _toggleCollapsed(collapsed) {
     if (collapsed) {
       this._transitionToHeight(this.props.collapsedHeight);
@@ -104,9 +109,7 @@ export default class Collapsible extends Component {
       }
       return;
     } else {
-      this._measureContent(contentHeight => {
-        this._transitionToHeight(contentHeight);
-      });
+      this._measureContent(this._afterMeasure);
     }
   }
 


### PR DESCRIPTION
I had an issue while using a collapsible that was to be collapsed while the keyboard was showing. When the device (iPhone X in this case) was rotated, the following series of events unfolds:
1. `KeyboardWillHide` event emitted
2. We pass `collapsed: false` to the `<Collapsible/>`
3. `_toggleCollapsed(false)` -> `_measureContent()` starts
4. `KeyboardWillShow` event emitted
5. We pass `collapsed: true` to the `<Collapsible/>`
6. `_toggleCollapsed(false)` -> `_transitionToHeight(0)`
7. measuring finishes
8. `_transitionToHeight(contentHeight)` is started due to callback from _measureContent
9. content now has a height, even though it has `collapsed: true` prop.

I'm not altogether sure why on iOS react native fires the KeyboardWillHide and KeyboardWillShow events one after the other when the device is rotated, but that seems to be the case.

The attached change makes the behaviour, instead of assuming that after measuring, the content should be shown uncollapsed; that after measuring the content should be shown in whatever state the collapsed property is once measuring is completed. Other than resolving my own issue it should work for other cases where the property changes rapidly.