### PR TITLE
Remove Accordion.handleErrors

### DIFF
--- a/Accordion.js
+++ b/Accordion.js
@@ -57,12 +57,6 @@ export default class Accordion extends Component {
     }
   }
 
-  handleErrors = () => {
-    if (!Array.isArray(this.props.sections)) {
-      throw new Error('Sections should be an array');
-    }
-  };
-
   render() {
     let viewProps = {};
     let collapsibleProps = {};
@@ -74,8 +68,6 @@ export default class Accordion extends Component {
         viewProps[key] = this.props[key];
       }
     });
-
-    this.handleErrors();
 
     const {
       activeSections,


### PR DESCRIPTION
Hi there!

I am opening a PR because raising an error here is a bit unnecessary. There is already a warning due to the `PropTypes`. This also blocks me because I am using `mobx-react` and `Mobx` wraps arrays with `observable()`, which will fail `Array.isArray()` test. I'm ok with keeping the warning though :)

Do you think you could merge that?