### PR TITLE
fix: Add sections to onChange props

### DIFF
--- a/Accordion.js
+++ b/Accordion.js
@@ -39,7 +39,7 @@ export default class Accordion extends Component {
     sectionContainerStyle: {},
   };
 
-  _toggleSection(section) {
+  _toggleSection(section, sections) {
     if (!this.props.disabled) {
       const { activeSections, expandMultiple, onChange } = this.props;
 
@@ -53,7 +53,7 @@ export default class Accordion extends Component {
         updatedSections = [section];
       }
 
-      onChange && onChange(updatedSections);
+      onChange && onChange(updatedSections, sections);
     }
   }
 
@@ -102,7 +102,7 @@ export default class Accordion extends Component {
             {expandFromBottom && renderCollapsible(section, key)}
 
             <Touchable
-              onPress={() => this._toggleSection(key)}
+              onPress={() => this._toggleSection(key, sections)}
               underlayColor={underlayColor}
               {...touchableProps}
             >

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ import Accordion from 'react-native-collapsible/Accordion';
 | **`renderHeader(content, index, isActive, sections)`**  | A function that should return a renderable representing the header                                             |
 | **`renderContent(content, index, isActive, sections)`** | A function that should return a renderable representing the content                                            |
 | **`renderSectionTitle(content, index, isActive)`**      | A function that should return a renderable representing the title of the section outside the touchable element |
-| **`onChange(indexes)`**                                 | A function that is called when the currently active section(s) are updated.                                    |
+| **`onChange(indexes, sections)`**                       | A function that is called when the currently active section(s) are updated.                                    |
 | **`activeSections`**                                    | Control which indices in the `sections` array are currently open. If empty, closes all sections.               |
 | **`underlayColor`**                                     | The color of the underlay that will show through when tapping on headers. Defaults to black.                   |
 | **`touchableComponent`**                                | The touchable component used in the Accordion. Defaults to `TouchableHighlight`                                |


### PR DESCRIPTION
When I tried to create a menu component using Accordion, I attempted to implement Accordion in Accordion.

The use case is below.
1. Perform specific processing at `onChange` (onPress)
   - => At that time Accordion will not open
   - Which menu was pressed is determined by the index of `onChange` (index)
1. When there is a nest Accordion
   - => Open Accordion with `onChange`

In such a case, you can not distinguish nested menus with the onChange index alone.
So, we added `sections` to props on `onChange`.
This section represents sections in the same hierarchy as `onChange`.

* * *

I thought that this problem can be implemented if we use `<Collapsible>` without using `<Accordion>`. However, in that case I thought that it was redundant, implementing a feature like `<Accordion>` in `<Collapsible>`.

I feel that adding the above props is smartest, but what about it?
