### PR TITLE
Accordion - Give ViewProps Priority

### DIFF
--- a/Accordion.d.ts
+++ b/Accordion.d.ts
@@ -106,6 +106,11 @@ export interface AccordionProps<T> {
    * Optional styling for the section container
    */
   sectionContainerStyle?: StyleProp<ViewStyle>;
+
+ /**
+   * Optional styling for the Accordion container
+   */
+  containerStyle?: StyleProp<ViewStyle>;
 }
 
 export default class Accordion<T> extends React.Component<AccordionProps<T>> {}

--- a/Accordion.js
+++ b/Accordion.js
@@ -26,6 +26,7 @@ export default class Accordion extends Component {
     expandMultiple: PropTypes.bool,
     onAnimationEnd: PropTypes.func,
     sectionContainerStyle: ViewPropTypes.style,
+    containerStyle: ViewPropTypes.style,
   };
 
   static defaultProps = {
@@ -71,6 +72,7 @@ export default class Accordion extends Component {
 
     const {
       activeSections,
+      containerStyle,
       sectionContainerStyle,
       expandFromBottom,
       sections,
@@ -94,7 +96,7 @@ export default class Accordion extends Component {
     );
 
     return (
-      <View {...viewProps}>
+      <View style={containerStyle} {...viewProps}>
         {sections.map((section, key) => (
           <View key={key} style={sectionContainerStyle}>
             {renderSectionTitle(section, key, activeSections.includes(key))}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ import Accordion from 'react-native-collapsible/Accordion';
 | **`expandFromBottom`**                                  | Expand content from the bottom instead of the top                                                              |
 | **`expandMultiple`**                                    | Allow more than one section to be expanded. Defaults to false.                                                 |
 | **`sectionContainerStyle`**                             | Optional styling for the section container.                                                                    |
+| **`containerStyle`**                                    | Optional styling for the Accordion container.                                                                  |
 
 ## Demo
 


### PR DESCRIPTION
Hi There! Thanks for making a great package!

React Native Collapsible really simplifies our code and is great to work with!

One issue we encountered is that we needed to pass down a `style` prop to the `Accordion` container `View` [here](https://github.com/oblador/react-native-collapsible/blob/567434e42e15810d8d52dac580970489d8627916/Accordion.js#L97). Unfortunately, the `Collapsible` component defines a `style` prop [here](https://github.com/oblador/react-native-collapsible/blob/567434e42e15810d8d52dac580970489d8627916/Collapsible.js#L16).

The code was written to give the `Collapsible` component's props priority when building out the proxy prop objects. This PR switches the logic such that React Native's `View` component props are first resolved, then the `Collapsible` props are resolved. 

This allows the caller to pass down a `style` prop to the root Accordion view.