### PR TITLE
Update Collapsible.js with useNativeDriver which allows parallel process

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -146,21 +146,16 @@ export default class Collapsible extends Component {
       this._animation.stop();
     }
     this.setState({ animating: true });
-    this._animation = Animated.timing(this.state.height, {
-      toValue: height,
-      duration,
-      easing,
-    }).start(() => {
-      if (this.unmounted) {
-        return;
-      }
-      this.setState({ animating: false }, () => {
-        if (this.unmounted) {
-          return;
-        }
-        this.props.onAnimationEnd();
-      });
-    });
+    this._animation = Animated.parallel([
+      Animated.timing(this.state.height, {
+        toValue: height,
+        duration,
+        easing
+      })
+    ],
+    {useNativeDriver: true}).start(() =>
+      this.setState({ animating: false }, this.props.onAnimationEnd)
+    );
   }
 
   _handleLayoutChange = event => {

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -146,14 +146,16 @@ export default class Collapsible extends Component {
       this._animation.stop();
     }
     this.setState({ animating: true });
-    this._animation = Animated.parallel([
-      Animated.timing(this.state.height, {
-        toValue: height,
-        duration,
-        easing
-      })
-    ],
-    {useNativeDriver: true}).start(() =>
+    this._animation = Animated.parallel(
+      [
+        Animated.timing(this.state.height, {
+          toValue: height,
+          duration,
+          easing,
+        }),
+      ],
+      { useNativeDriver: true }
+    ).start(() =>
       this.setState({ animating: false }, this.props.onAnimationEnd)
     );
   }


### PR DESCRIPTION
This PR continues with the changes made in https://github.com/oblador/react-native-collapsible/pull/235 with merge conflicts resolved. 

With this change, animations can run parallel to other processes taking place such as AWS AppSync queries or mutations