### PR TITLE
only use a fixed/calculated height during animation

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -182,7 +182,7 @@ export default class Collapsible extends Component {
     const { collapsed, enablePointerEvents } = this.props;
     const { height, contentHeight, measuring, measured } = this.state;
     const hasKnownHeight = !measuring && (measured || collapsed);
-    const style = hasKnownHeight && {
+    const style = hasKnownHeight && animating && {
       overflow: 'hidden',
       height: height,
     };


### PR DESCRIPTION
I am not sure if its my content, an issue of timing of when the measurement is taken, or just a bug in this or core react-native, but the measured size for my content is ALWAYS wrong.   The measured height is between 10 and 28 pixels too large.  I have fought with this for a while but I found that if I REMOVE the explicit height (all my content is in flex boxes and does include some SVG component) it works perfectly.  Seeing that height is used for the animating process, I made this small PR to only apply height during the animating.  It should not (as far as I can tell) change the components default behavior so I am hoping this will be accepted.