### PR TITLE
Set overflow of parent Animated.View to "scroll"

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -183,7 +183,7 @@ export default class Collapsible extends Component {
     const { height, contentHeight, measuring, measured } = this.state;
     const hasKnownHeight = !measuring && (measured || collapsed);
     const style = hasKnownHeight && {
-      overflow: 'hidden',
+      overflow: 'scroll',
       height: height,
     };
     const contentStyle = {};


### PR DESCRIPTION
The fix is related to https://github.com/oblador/react-native-collapsible/issues/51
onLayout is not being called otherwise, which makes changing the height of the collapsible items inside of a FlatList in my case impossible. Using RN 0.61.5