### PR TITLE
Show overflow when not collapsed

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -186,7 +186,6 @@ export default class Collapsible extends Component {
       overflow: collapsed ? 'hidden' : 'visible',
       height: height,
     };
-    style && (style.overflow = collapsed ? 'hidden' : 'visible');
     const contentStyle = {};
     if (measuring) {
       contentStyle.position = 'absolute';

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -183,9 +183,10 @@ export default class Collapsible extends Component {
     const { height, contentHeight, measuring, measured } = this.state;
     const hasKnownHeight = !measuring && (measured || collapsed);
     const style = hasKnownHeight && {
-      overflow: 'hidden',
+      overflow: collapsed ? 'hidden' : 'visible',
       height: height,
     };
+    style && (style.overflow = collapsed ? 'hidden' : 'visible');
     const contentStyle = {};
     if (measuring) {
       contentStyle.position = 'absolute';


### PR DESCRIPTION
Show overflow when not collapsed. My shadow is being cut off when not collapsed.

![IMG_ECC9ADADA03F-1](https://user-images.githubusercontent.com/14742892/77662801-fda47080-6f84-11ea-887d-18cf1f8233e1.jpeg)
