### PR TITLE
Specify useNativeDriver = "false"

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [oblador]

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -147,6 +147,7 @@ export default class Collapsible extends Component {
     }
     this.setState({ animating: true });
     this._animation = Animated.timing(this.state.height, {
+      useNativeDriver: false,
       toValue: height,
       duration,
       easing,


### PR DESCRIPTION
Solves this warning on RN 0.62.0:

```ruby
Animated: useNativeDriver was not specified.
This is a required option and must be explicitly set to true or false
```