### PR TITLE
Fix getNode warning

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -70,6 +70,14 @@ export default class Collapsible extends Component {
     this.contentHandle = ref;
   };
 
+  _getNode = () => {
+    if (this.contentHandle.measure) {
+      return this.contentHandle;
+    } else {
+      return this.contentHandle.getNode();
+    }
+  };
+
   _measureContent(callback) {
     this.setState(
       {
@@ -85,7 +93,7 @@ export default class Collapsible extends Component {
               () => callback(this.props.collapsedHeight)
             );
           } else {
-            this.contentHandle.getNode().measure((x, y, width, height) => {
+            this._getNode().measure((x, y, width, height) => {
               this.setState(
                 {
                   measuring: false,


### PR DESCRIPTION
This PR gets rid of RN 0.62.0 new warning:
```javascript
Calling getNode() on the ref of an Animated component
is no longer necessary. You can now directly use the ref
instead. This method will be removed in a future release.
```
I tried to make changes in the safest way, so that it will work with older RN versions, too.
