### PR TITLE
Remove getNode() for React Native >= 0.62

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -85,7 +85,13 @@ export default class Collapsible extends Component {
               () => callback(this.props.collapsedHeight)
             );
           } else {
-            this.contentHandle.getNode().measure((x, y, width, height) => {
+            let ref;
+            if (typeof this.contentHandle.measure === 'function') {
+              ref = this.contentHandle;
+            } else {
+              ref = this.contentHandle.getNode();
+            }
+            ref.measure((x, y, width, height) => {
               this.setState(
                 {
                   measuring: false,


### PR DESCRIPTION
getNode() is now deprecated from RN v0.62 and it's throwing a deprecation warning: https://reactnative.dev/blog/2020/03/26/version-0.62