### PR TITLE
fix: replace propTypes with defaultProps

### DIFF
--- a/Accordion.js
+++ b/Accordion.js
@@ -4,7 +4,7 @@ import { View, TouchableHighlight } from 'react-native';
 import Collapsible from './Collapsible';
 import { ViewPropTypes } from './config';
 
-const COLLAPSIBLE_PROPS = Object.keys(Collapsible.propTypes);
+const COLLAPSIBLE_PROPS = Object.keys(Collapsible.defaultProps);
 const VIEW_PROPS = Object.keys(ViewPropTypes);
 
 export default class Accordion extends Component {

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -25,7 +25,9 @@ export default class Collapsible extends Component {
     enablePointerEvents: false,
     duration: 300,
     easing: 'easeOutCubic',
+    style: undefined,
     onAnimationEnd: () => null,
+    children: null,
   };
 
   constructor(props) {


### PR DESCRIPTION
When used with [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types), `Collapsible.propTypes` will always be `undefined`.      
Replace `propTypes` with `defaultProps` should fix this problem.

Related issue: https://github.com/necolas/react-native-web/issues/423
