### PR TITLE
Fixed the cannot read property 'style' of undefined issue for react-native-web > 0.12

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,2 +1,2 @@
 import { View, ViewPropTypes as RNViewPropTypes } from 'react-native';
-export const ViewPropTypes = RNViewPropTypes || View.propTypes || { style: {} };
+export const ViewPropTypes = RNViewPropTypes || View.propTypes || { style: () => {} };

--- a/config/index.js
+++ b/config/index.js
@@ -1,2 +1,2 @@
 import { View, ViewPropTypes as RNViewPropTypes } from 'react-native';
-export const ViewPropTypes = RNViewPropTypes || View.propTypes;
+export const ViewPropTypes = RNViewPropTypes || View.propTypes || { style: {} };


### PR DESCRIPTION
The issue is caused by the change made in 
[react-native-web 0.12.0](https://github.com/necolas/react-native-web/releases/tag/0.12.0):
> Remove prop types exports from the package. These are deprecated in React Native and introduce significant DEV time performance cost. Flow types are now preferred (1ad1693)

More details here: [PR#1537](https://github.com/necolas/react-native-web/issues/1537)

I suggest the fix by adding extra ``|| { style: () => {} }`` statement.

This way it still works with react-native-web, but it also would work with 0.12.0.

This way it compiles with a warning:
> Attempted import error: 'ViewPropTypes' is not exported from 'react-native-web/dist/index' (imported as 'RNViewPropTypes')
but it works.

We can of course just get rid of it ViewPropTypes, but then it might stop working with older versions of react-native-web, so maybe we can keep it with a warning for some time until most of the users update