### PR TITLE
Fix: ERROR Invariant Violation: [3633,"RCTView",{"height":"<<NaN>>"}] is not usable as a native method argument

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -154,7 +154,7 @@ export default class Collapsible extends Component {
     this.setState({ animating: true });
     this._animation = Animated.timing(this.state.height, {
       useNativeDriver: false,
-      toValue: height,
+      toValue: height ? height : 0,
       duration,
       easing,
     }).start(() => {


### PR DESCRIPTION
![React Native ERROR](https://i.epvpimg.com/4uiIbab.jpg)

**How it occured** -> when animating one of multiple Collapsible items within a FlatList.

The problem came from **Collapsible.js / line 155 to line 170**, fixed by adding a fallback value for **height**:

```diff
this._animation = Animated.timing(this.state.height, {
      useNativeDriver: false,
-     toValue: height,
+     toValue: height ? height : 0,
      duration,
      easing,
    }).start(() => {
      if (this.unmounted) {
        return;
      }
      this.setState({ animating: false }, () => {
        if (this.unmounted) {
          return;
        }
        this.props.onAnimationEnd();
      });
    });
```
**STACKTRACE ERROR:**
```javascript
ERROR Invariant Violation: [3633,"RCTView",{"height":"<<NaN>>"}] is not usable as a native method argument

This error is located at:
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Collapsible.js:220)
    in Collapsible (at Home.js:602)
    in RCTView (at View.js:34)
    in View (at VirtualizedList.js:2120)
    in CellRenderer (at VirtualizedList.js:900)
    in RCTView (at View.js:34)
    in View (at ScrollView.js:1124)
    in RCTScrollView (at ScrollView.js:1250)
    in AndroidSwipeRefreshLayout (at RefreshControl.js:197)
    in RefreshControl (at Home.js:1360)
    in ScrollView (at ScrollView.js:1286)
    in ScrollView (at VirtualizedList.js:1329)
    in VirtualizedList (at FlatList.js:624)
    in FlatList (at Home.js:1358)
    in RCTView (at View.js:34)
    in View (at Home.js:1073)
    in Home (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:153)
    in RCTView (at View.js:34)
    in View (created by SceneView)
    in SceneView (created by Pager)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:240)
    in AnimatedComponent(View) (created by PanGestureHandler)
    in PanGestureHandler (created by Pager)
    in Pager (created by TabView)
    in RCTView (at View.js:34)
    in View (at GestureHandlerRootView.android.js:26)
    in GestureHandlerRootView (created by TabView)
    in TabView (at MaterialTopTabView.tsx:51)
    in MaterialTopTabView (at createMaterialTopTabNavigator.tsx:44)
    in MaterialTopTabNavigator (at Auth.js:29)
    in MyTabs (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:153)
    in RCTView (at View.js:34)
    in View (at ResourceSavingScene.tsx:58)
    in RCTView (at View.js:34)
    in View (at ResourceSavingScene.tsx:41)
    in ResourceSavingScene (at DrawerView.tsx:183)
    in RCTView (at View.js:34)
    in View (at src/index.native.js:123)
    in ScreenContainer (at DrawerView.tsx:162)
    in RCTView (at View.js:34)
    in View (at Drawer.tsx:645)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:240)
    in AnimatedComponent(View) (at Drawer.tsx:638)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:240)
    in AnimatedComponent(View) (at Drawer.tsx:628)
    in PanGestureHandler (at GestureHandlerNative.tsx:13)
    in PanGestureHandler (at Drawer.tsx:619)
    in DrawerView (at DrawerView.tsx:215)
    in SafeAreaProviderCompat (at DrawerView.tsx:213)
    in RCTView (at View.js:34)
    in View (at GestureHandlerRootView.android.js:26)
    in GestureHandlerRootView (at DrawerView.tsx:212)
    in DrawerView (at createDrawerNavigator.tsx:47)
    in DrawerNavigator (at Auth.js:49)
    in RightDrawerHome (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:153)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:245)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:244)
    in RCTView (at View.js:34)
    in View (at CardSheet.tsx:33)
    in ForwardRef(CardSheet) (at Card.tsx:573)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:555)
    in PanGestureHandler (at GestureHandlerNative.tsx:13)
    in PanGestureHandler (at Card.tsx:549)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:544)
    in RCTView (at View.js:34)
    in View (at Card.tsx:538)
    in Card (at CardContainer.tsx:206)
    in CardContainer (at CardStack.tsx:619)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:84)
    in MaybeScreen (at CardStack.tsx:612)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:54)
    in MaybeScreenContainer (at CardStack.tsx:494)
    in CardStack (at StackView.tsx:462)
    in KeyboardManager (at StackView.tsx:458)
    in RNCSafeAreaView (at src/index.tsx:28)
    in SafeAreaProvider (at SafeAreaProviderCompat.tsx:42)
    in SafeAreaProviderCompat (at StackView.tsx:455)
    in GestureHandlerRootView (at GestureHandlerRootView.android.js:31)
    in GestureHandlerRootView (at StackView.tsx:454)
    in StackView (at createStackNavigator.tsx:87)
    in StackNavigator (at Auth.js:98)
    in Auth (at Main.js:12)
    in EnsureSingleNavigator (at BaseNavigationContainer.tsx:409)
    in ForwardRef(BaseNavigationContainer) (at NavigationContainer.tsx:91)
    in ThemeProvider (at NavigationContainer.tsx:90)
    in ForwardRef(NavigationContainer) (at Main.js:11)
    in Unknown (at App.js:14)
    in Provider (at App.js:13)
    in App (at renderApplication.js:45)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:106)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:132)
    in AppContainer (at renderApplication.js:39)
```