### PR TITLE
Add 'renderChildrenCollapsed' to Accordion 

### DIFF
--- a/Accordion.d.ts
+++ b/Accordion.d.ts
@@ -141,6 +141,11 @@ export interface AccordionProps<T> {
    * @default false
    */
   renderAsFlatList?: boolean;
+
+  /**
+   * Render children in collapsible even if not visible.
+   */
+  renderChildrenCollapsed: boolean;
 }
 
-export default class Accordion<T> extends React.Component<AccordionProps<T>> {}
+export default class Accordion<T> extends React.Component<AccordionProps<T>> { }

--- a/Accordion.js
+++ b/Accordion.js
@@ -123,7 +123,8 @@ export default class Accordion extends Component {
     });
 
     const renderCollapsible = (section, key) => (
-      <Collapsible renderChildrenCollapsed={renderChildrenCollapsed}
+      <Collapsible
+        renderChildrenCollapsed={renderChildrenCollapsed}
         collapsed={!activeSections.includes(key)}
         {...collapsibleProps}
         onAnimationEnd={() => onAnimationEnd(section, key)}

--- a/Accordion.js
+++ b/Accordion.js
@@ -26,6 +26,7 @@ export default class Accordion extends Component {
     onAnimationEnd: () => null,
     sectionContainerStyle: {},
     renderAsFlatList: false,
+    renderChildrenCollapsed: true,
   };
 
   _toggleSection(section) {
@@ -106,6 +107,7 @@ export default class Accordion extends Component {
       disabled,
       renderAsFlatList,
       keyExtractor,
+      renderChildrenCollapsed,
       ...restProps
     } = this.props;
 
@@ -121,7 +123,7 @@ export default class Accordion extends Component {
     });
 
     const renderCollapsible = (section, key) => (
-      <Collapsible
+      <Collapsible renderChildrenCollapsed={renderChildrenCollapsed}
         collapsed={!activeSections.includes(key)}
         {...collapsibleProps}
         onAnimationEnd={() => onAnimationEnd(section, key)}


### PR DESCRIPTION
Added the same 'renderChildrenCollapsed' prop to Accordion, which passes it to Collapsible.  Allowing deeply nested accordions.