### PR TITLE
Support for React 18

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,10 @@ export interface CollapsibleProps {
    * Function called when the animation finished
    */
   onAnimationEnd?: () => void;
+  /** 
+   * Add children JSX
+   */
+  children: React.ReactNode;
 }
 
 export default class Collapsible extends React.Component<CollapsibleProps> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,9 +93,7 @@ export interface CollapsibleProps {
    * Function called when the animation finished
    */
   onAnimationEnd?: () => void;
-  /** 
-   * Add children JSX
-   */
+
   children: React.ReactNode;
 }
 


### PR DESCRIPTION
This PR supports React 18 as `children` prop has been removed from React 18 so added support here, please merge.