### PR TITLE
fix: extend AccordionProps from CollapsibleProps

### DIFF
--- a/Accordion.d.ts
+++ b/Accordion.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
-import { EasingMode } from './index';
+import { CollapsibleProps, EasingMode } from './index';
 
-export interface AccordionProps<T> {
+export interface AccordionProps<T> extends Omit<CollapsibleProps, 'children'> {
   /**
    * An array of sections passed to the render methods
    */


### PR DESCRIPTION
Looks to me like `Accordion` actually accepts all of the `Collapsible` props (apart from children):

https://github.com/oblador/react-native-collapsible/blob/a46d0a5a48e0e3d6ec9cc7986b69999ada825f09/Accordion.js#L5-L15

https://github.com/oblador/react-native-collapsible/blob/a46d0a5a48e0e3d6ec9cc7986b69999ada825f09/Accordion.js#L116-L120

