### PR TITLE
Fix Collapsible TS Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,4 +97,6 @@ export interface CollapsibleProps {
   children: React.ReactNode;
 }
 
-export default class Collapsible extends React.Component<CollapsibleProps> {}
+export default class Collapsible extends React.Component<
+  React.PropsWithChildren<CollapsibleProps>
+> {}


### PR DESCRIPTION
New type definitions in react 18.0.0 (@types/react) flag this component for having children when it it's type definition doesn't say it has any children. This change should be backwards compatible since PropsWithChildren has existed for awhile and this is just a clarification on the underlying type.