### PR TITLE
fix: content is not displayed if collaped default to true

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -51,6 +51,12 @@ export default class Collapsible extends Component {
     }
   }
 
+  componentDidMount() {
+    if (!this.props.collapsed) {
+      this._toggleCollapsed(this.props.collapsed);
+    }
+  }
+
   contentHandle = null;
 
   _handleRef = (ref) => {


### PR DESCRIPTION
- This PR will fix the issue content is not displayed if collapsed is true in [#479 ](https://github.com/oblador/react-native-collapsible/issues/479)

- Here is the result after the fix:

Android:

https://github.com/user-attachments/assets/13f6fb85-0e41-4362-8c6e-3f1ace931147

Ios:








https://github.com/user-attachments/assets/2c6cd88c-a412-409f-a340-8e8daf4f0e4a
