### PR TITLE
Fix: issue with initial rendering of collapsible section

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -26,6 +26,13 @@ export default class Collapsible extends Component {
     };
   }
 
+  static getDerivedStateFromProps(props, state) {
+    if (!props.collapsed) {
+      return { measured: false };
+    }
+    return null;
+  }
+
   componentDidUpdate(prevProps) {
     if (prevProps.collapsed !== this.props.collapsed) {
       this.setState({ measured: false }, () =>

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -193,9 +193,9 @@ export default class Collapsible extends Component {
       animating,
     } = this.state;
     const hasKnownHeight = !measuring && (measured || collapsed);
-    const style = hasKnownHeight && {
+    const style = {
       overflow: 'hidden',
-      height: height,
+      height: hasKnownHeight ? height : 0,
     };
     const contentStyle = {};
     if (measuring) {

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -193,9 +193,9 @@ export default class Collapsible extends Component {
       animating,
     } = this.state;
     const hasKnownHeight = !measuring && (measured || collapsed);
-    const style = {
+    const style = hasKnownHeight && {
       overflow: 'hidden',
-      height: hasKnownHeight ? height : 0,
+      height: height,
     };
     const contentStyle = {};
     if (measuring) {


### PR DESCRIPTION
For Accordion component:

1. When component renders, first index will be open.
2. Reverted code because it was not getting height as zero when view is expanded.